### PR TITLE
adding opunit version to local check

### DIFF
--- a/test/local.yml
+++ b/test/local.yml
@@ -2,6 +2,9 @@
    description: "Essential development tools"
    checks:
      - version:
+         cmd: opunit --version
+         range: ^0.7.6
+     - version:
          cmd: node --version
          range: ^10.x.x
      - version:

--- a/test/local.yml
+++ b/test/local.yml
@@ -11,5 +11,5 @@
          cmd: VBoxManage --version
          range: 5.2.x
      - version:
-         cmd: baker --version
-         range: ^0.6.15
+         cmd: bakerx --version
+         range: ^0.6.12


### PR DESCRIPTION
- Making sure opunit > `v0.7.6` is installed.
- Fixing bakerx version check. 